### PR TITLE
Expand layers

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -11,6 +11,9 @@ parts:
     - file: demos/simple_ode.py
     - file: demos/solve_many_odes.py
     - file: demos/niederer_benchmark.py
+    - file: demos/planar_slab.py
+    - file: demos/diffusion.py
+    - file: demos/endocardial_stimulation_single.py
     - file: demos/endocardial_stimulation.py
   - caption: Verification
     chapters:

--- a/demos/diffusion.py
+++ b/demos/diffusion.py
@@ -1,0 +1,35 @@
+import beat
+import dolfin
+import matplotlib.pyplot as plt
+
+
+def main():
+    mesh = dolfin.UnitSquareMesh(20, 20)
+
+    # S = Constant(0.0)  # source term
+    S = dolfin.Constant(1.0)
+    S1_subdomain = dolfin.CompiledSubDomain(
+        "x[0] <= L + DOLFIN_EPS && x[1] <= L + DOLFIN_EPS",
+        L=0.3,
+    )
+    S1_markers = dolfin.MeshFunction("size_t", mesh, 2)
+    S1_marker = 1
+    S1_subdomain.mark(S1_markers, S1_marker)
+
+    I_s = beat.base_model.Stimulus(
+        expr=S, dz=dolfin.dx(domain=mesh, subdomain_data=S1_markers)(S1_marker)
+    )
+
+    time = dolfin.Constant(0.0)
+
+    model = beat.MonodomainModel(time=time, mesh=mesh, M=1.0, I_s=I_s)
+    res = model.solve((0, 2.5), dt=0.1)
+
+    fig = plt.figure()
+    im = dolfin.plot(res.state)
+    fig.colorbar(im)
+    fig.savefig("diffusion.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/diffusion.py
+++ b/demos/diffusion.py
@@ -1,3 +1,10 @@
+# # Diffusion in a square domain with a stimulus in the lower left corner
+#
+# This demo solves the monodomain equation on a square domain with a
+# stimulus in the lower left corner. The stimulus is defined as a
+# constant value in a subdomain.
+#
+
 import beat
 import dolfin
 import matplotlib.pyplot as plt
@@ -6,7 +13,6 @@ import matplotlib.pyplot as plt
 def main():
     mesh = dolfin.UnitSquareMesh(20, 20)
 
-    # S = Constant(0.0)  # source term
     S = dolfin.Constant(1.0)
     S1_subdomain = dolfin.CompiledSubDomain(
         "x[0] <= L + DOLFIN_EPS && x[1] <= L + DOLFIN_EPS",

--- a/demos/endocardial_stimulation.py
+++ b/demos/endocardial_stimulation.py
@@ -1,7 +1,7 @@
-# # Endocardial stimulation
+# # Endocardial stimulation (multiple cell models)
 # In this demo we stimulate a Bi-ventricular geometry at the endocardium and compute a pseudo-ecg
 #
-# ```{figure} docs/_static/torso_electrodes.png
+# ```{figure} ../docs/_static/torso_electrodes.png
 # ---
 # name: torso_electrodes
 # ---
@@ -297,7 +297,9 @@ def main():
         v_index=v_index,
     )
 
-    T = 500
+    T = 1
+    # Change to 500 to simulate the full cardiac cycle
+    # T = 500
     t = 0.0
     dt = 0.05
     solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/demos/endocardial_stimulation_single.py
+++ b/demos/endocardial_stimulation_single.py
@@ -248,8 +248,9 @@ def main():
         num_states=len(init_states),
         v_index=model.state_indices("V"),
     )
-
-    T = 500
+    T = 1
+    # Change to 500 to simulate the full cardiac cycle
+    # T = 500
     t = 0.0
     dt = 0.05
     solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/demos/endocardial_stimulation_single.py
+++ b/demos/endocardial_stimulation_single.py
@@ -1,7 +1,7 @@
 # # Endocardial stimulation
 # In this demo we stimulate a Bi-ventricular geometry at the endocardium and compute a pseudo-ecg
 #
-# ```{figure} docs/_static/torso_electrodes.png
+# ```{figure} ../docs/_static/torso_electrodes.png
 # ---
 # name: torso_electrodes
 # ---

--- a/demos/niederer_benchmark.py
+++ b/demos/niederer_benchmark.py
@@ -16,7 +16,7 @@ import numpy.typing as npt
 
 import beat
 
-import beat.cellmodels.tentusscher_panfilov_2006_epi_cell as model
+import beat.cellmodels.tentusscher_panfilov_2006.epi as model
 
 
 def setup_initial_conditions() -> npt.NDArray:
@@ -145,7 +145,8 @@ def main():
         v_index=model.state_indices("V"),
     )
 
-    T = 100
+    T = 1
+    # T = 100  # Change to 100 to reproduce Niederer benchmark
     t = 0.0
     dt = 0.05
     solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/demos/planar_slab.py
+++ b/demos/planar_slab.py
@@ -1,3 +1,9 @@
+# # Planar slab
+# This demo simulates a planar slab of cardiac tissue with a stimulus applied
+# at the left end. The stimulus is applied for 2 ms and then turned off.
+# ECGs are computed at 6 points on the surface of the slab.
+#
+
 import dolfin
 import numpy as np
 from collections import defaultdict
@@ -293,7 +299,9 @@ def main(datadir=Path("planar_slab")):
         v_index=v_index,
     )
 
-    T = 500
+    T = 1
+    # Change to 500 to simulate the full cardiac cycle
+    # T = 500
     t = 0.0
     dt = 0.05
     solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)

--- a/demos/planar_slab.py
+++ b/demos/planar_slab.py
@@ -218,13 +218,17 @@ def main(datadir=Path("planar_slab")):
 
     V = dolfin.FunctionSpace(mesh, "Lagrange", 1)
     markers = dolfin.Function(V)
-    arr = markers.vector().get_local().copy()
-    v2d = dolfin.vertex_to_dof_map(V)
+    arr = beat.utils.expand_layer(
+        markers=markers,
+        mfun=mfun,
+        endo_markers=[1],
+        epi_markers=[2],
+        endo_marker=1,
+        epi_marker=2,
+        endo_size=0.3,
+        epi_size=0.3,
+    )
 
-    for marker in [0, 1, 2]:
-        for facet in mfun.where_equal(marker):
-            f = dolfin.Facet(mesh, facet)
-            arr[v2d[f.entities(0)]] = marker
     markers.vector().set_local(arr)
 
     with dolfin.XDMFFile((datadir / "markers.xdmf").as_posix()) as xdmf:
@@ -299,9 +303,9 @@ def main(datadir=Path("planar_slab")):
         v_index=v_index,
     )
 
-    T = 1
+    # T = 1
     # Change to 500 to simulate the full cardiac cycle
-    # T = 500
+    T = 500
     t = 0.0
     dt = 0.05
     solver = beat.MonodomainSplittingSolver(pde=pde, ode=ode)
@@ -326,5 +330,5 @@ def main(datadir=Path("planar_slab")):
 
 
 if __name__ == "__main__":
-    # main()
-    compute_ecg_recovery()
+    main()
+    # compute_ecg_recovery()

--- a/demos/solve_many_odes.py
+++ b/demos/solve_many_odes.py
@@ -40,7 +40,7 @@ t0 = 0.0
 
 V_index = model.state_indices("V")
 
-nT = int((t_bound - t0) / dt)
+nT = int((t_bound - t0) / dt) - 1
 V = np.zeros((nT, num_points))
 t0 = perf_counter()
 # values = np.zeros_like(ic)

--- a/src/beat/__init__.py
+++ b/src/beat/__init__.py
@@ -6,6 +6,7 @@ from . import (
     cellmodels,
     odesolver,
     ecg,
+    utils,
 )
 
 from .monodomain_model import MonodomainModel
@@ -24,4 +25,5 @@ __all__ = [
     "monodomain_solver",
     "MonodomainSplittingSolver",
     "ecg",
+    "utils",
 ]

--- a/src/beat/utils.py
+++ b/src/beat/utils.py
@@ -1,0 +1,102 @@
+import logging
+import dolfin
+import numpy.typing as npt
+import numpy as np
+import ufl_legacy as ufl
+
+
+logger = logging.getLogger(__name__)
+
+
+def expand_layer(
+    markers: dolfin.Function,
+    mfun: dolfin.MeshFunction,
+    endo_markers: list[int],
+    epi_markers: list[int],
+    endo_marker: int,
+    epi_marker: int,
+    endo_size: float,
+    epi_size: float,
+) -> npt.NDArray:
+    """Expand the endo and epi markers to the rest of the mesh
+    with a given size
+
+    Parameters
+    ----------
+    markers : dolfin.Function
+        Function where the markers are stored
+    mfun : dolfin.MeshFunction
+        Mesh function where the markers are stored
+    endo_markers: list[int]
+        List of markers for the endocardium. Should
+        be a subset of the markers in mfun
+    epimarkers: list[int]
+        List of markers for the epicardium. Should
+        be a subset of the markers in mfun
+    endo_marker : int
+        Marker for the endocardium. Used to set the
+        marker on the array that is returned.
+    epi_marker : int
+        Marker for the epicardium. Used to set the
+        marker on the array that is returned.
+    endo_size : float
+        Size of the endocardium
+    epi_size : float
+        Size of the epicardium
+
+    Returns
+    -------
+    npt.NDArray
+        Array with the markers
+    """
+    # Find the rest of the laplace solutions
+    V = markers.function_space()
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    arr = markers.vector().get_local().copy()
+    sol = dolfin.Function(V)
+
+    a = ufl.dot(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    L = v * dolfin.Constant(0) * ufl.dx
+
+    solver = dolfin.PETScKrylovSolver()
+    dolfin.PETScOptions.set("ksp_type", "cg")
+    dolfin.PETScOptions.set("ksp_norm_type", "unpreconditioned")
+    dolfin.PETScOptions.set("ksp_atol", 1e-15)
+    dolfin.PETScOptions.set("ksp_rtol", 1e-10)
+    dolfin.PETScOptions.set("ksp_max_it", 10_000)
+    dolfin.PETScOptions.set("ksp_error_if_not_converged", False)
+    # if ksp_monitor:
+    #     dolfin.PETScOptions.set("ksp_monitor")
+    # if ksp_view:
+    #     dolfin.PETScOptions.set("ksp_view")
+    dolfin.PETScOptions.set("pc_type", "hypre")
+    dolfin.PETScOptions.set("pc_hypre_type", "boomeramg")
+    # if pc_view:
+    #     dolfin.PETScOptions.set("pc_view")
+    solver.set_from_options()
+    sol_arrs = []
+
+    for endo in endo_markers:
+        for epi in epi_markers:
+            sol.vector()[:] = 0
+
+            # Iterate over the three different cases
+            logger.info("Solving Laplace equation")
+            bcs = [
+                dolfin.DirichletBC(V, 0, mfun, endo, "topological"),
+                dolfin.DirichletBC(V, 1, mfun, epi, "topological"),
+            ]
+            A, b = dolfin.assemble_system(a, L, bcs)
+
+            solver.set_operator(A)
+            solver.solve(sol.vector(), b)
+
+            sol_arrs.append(sol.vector().get_local())
+
+    # In BiV we have have one epi and two endo solutions
+    # We take the minimum of the two endo solutions
+    sol_arr = np.min(sol_arrs, axis=0)
+    arr[sol_arr < endo_size] = endo_marker
+    arr[sol_arr > 1 - epi_size] = epi_marker
+    return arr

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,73 @@
+import numpy as np
+import dolfin
+import beat
+
+
+def test_expand_layer_single():
+    mesh = dolfin.UnitSquareMesh(10, 10)
+
+    mfun = dolfin.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
+    mfun.set_all(0)
+    mid_marker = 0
+    endo_marker = 1
+    epi_marker = 2
+    dolfin.CompiledSubDomain("near(x[0], 0)").mark(mfun, endo_marker)
+    dolfin.CompiledSubDomain("near(x[0], 1)").mark(mfun, epi_marker)
+
+    V = dolfin.FunctionSpace(mesh, "Lagrange", 1)
+    markers = dolfin.Function(V)
+    arr = beat.utils.expand_layer(
+        markers=markers,
+        mfun=mfun,
+        endo_markers=[endo_marker],
+        epi_markers=[epi_marker],
+        endo_marker=endo_marker,
+        epi_marker=epi_marker,
+        endo_size=0.3,
+        epi_size=0.3,
+    )
+
+    markers.vector().set_local(arr)
+
+    # Just check a few values
+    for x in [0.0, 0.1, 0.2]:
+        for y in [0.0, 0.5, 1.0]:
+            assert np.isclose(markers(x, y), endo_marker)
+            assert np.isclose(markers(x + 0.4, y), mid_marker)
+            assert np.isclose(markers(1 - x, y), epi_marker)
+
+
+def test_expand_layer_double():
+    mesh = dolfin.UnitSquareMesh(10, 10)
+
+    mfun = dolfin.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
+    mfun.set_all(0)
+    mid_marker = 0
+    endo_marker = 1
+    endo_marker2 = 2
+    epi_marker = 3
+    dolfin.CompiledSubDomain("near(x[0], 0) && x[1] <= 0.5").mark(mfun, endo_marker)
+    dolfin.CompiledSubDomain("near(x[0], 0) && x[1] >= 0.5").mark(mfun, endo_marker2)
+    dolfin.CompiledSubDomain("near(x[0], 1)").mark(mfun, epi_marker)
+
+    V = dolfin.FunctionSpace(mesh, "Lagrange", 1)
+    markers = dolfin.Function(V)
+    arr = beat.utils.expand_layer(
+        markers=markers,
+        mfun=mfun,
+        endo_markers=[endo_marker, endo_marker2],
+        epi_markers=[epi_marker],
+        endo_marker=1,
+        epi_marker=epi_marker,
+        endo_size=0.3,
+        epi_size=0.3,
+    )
+
+    markers.vector().set_local(arr)
+
+    # Just check a few values
+    for x in [0.0, 0.1, 0.2]:
+        for y in [0.0, 0.5, 1.0]:
+            assert np.isclose(markers(x, y), endo_marker)
+            assert np.isclose(markers(x + 0.4, y), mid_marker)
+            assert np.isclose(markers(1 - x, y), epi_marker)


### PR DESCRIPTION
Given makers on the surface, make it possible to mark the nodes close to the surface by solving the Laplace equation. For example on a BiV mesh we will get the following markers by using a size of 30%
![Screenshot 2023-12-11 at 15 51 41](https://github.com/finsberg/fenics-beat/assets/2010323/b118208f-794f-48cd-8031-c66a0655baa1)

This will now also give us the correct sign on the ECG for the planer wave


![ecg_tentusscher_panfilov_2006](https://github.com/finsberg/fenics-beat/assets/2010323/131d20a7-3da4-4aaa-ad64-a3205bb61a65)
