### PR TITLE
Add tests for multiple spaces

### DIFF
--- a/src/beat/odesolver.py
+++ b/src/beat/odesolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import NamedTuple, Callable
+import abc
+from typing import NamedTuple, Callable, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -58,8 +59,55 @@ class ODESystemSolver:
         )
 
 
+class BaseDolfinODESolver(abc.ABC):
+    v_ode: dolfin.Function
+    v_pde: dolfin.Function
+    _metdata: dict[str, Any] | None = None
+
+    def _initialize_metadata(self):
+        if self.v_ode.ufl_element().family() == "Quadrature":
+            self._metadata = {"quadrature_degree": self.v_ode.ufl_element().degree()}
+        else:
+            self._metadata = None
+
+    @abc.abstractmethod
+    def to_dolfin(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def from_dolfin(self) -> None:
+        pass
+
+    def ode_to_pde(self) -> None:
+        """Projects v_ode (DG0, quadrature space, ...) into v_pde (CG1)"""
+        local_project(
+            self.v_ode,
+            self.v_pde.function_space(),
+            self.v_pde,
+            metadata=self._metadata,
+        )
+
+    def pde_to_ode(self) -> None:
+        """Projects v_pde (CG1) into v_ode (DG0, quadrature space, ...)"""
+        local_project(
+            self.v_pde,
+            self.v_ode.function_space(),
+            self.v_ode,
+            metadata=self._metadata,
+        )
+
+    @abc.abstractmethod
+    def step(self, t0: float, dt: float) -> None:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def full_values(self) -> npt.NDArray:
+        pass
+
+
 @dataclass
-class DolfinODESolver:
+class DolfinODESolver(BaseDolfinODESolver):
     v_ode: dolfin.Function
     v_pde: dolfin.Function
     init_states: npt.NDArray
@@ -80,6 +128,7 @@ class DolfinODESolver:
             states=self._values,
             parameters=self.parameters,
         )
+        self._initialize_metadata()
 
     def to_dolfin(self) -> None:
         """Assign values from numpy array to dolfin function"""
@@ -88,14 +137,6 @@ class DolfinODESolver:
     def from_dolfin(self) -> None:
         """Assign values from dolfin function to numpy array"""
         self._values[self.v_index, :] = self.v_ode.vector().get_local()
-
-    # ode_to_pde projects v_ode (DG0, quadrature space, ...) into v_pde (CG1)
-    def ode_to_pde(self) -> None:
-        local_project(self.v_ode, self.v_pde.function_space(), self.v_pde)
-
-    # pde_to_ode projects v_pde (CG1) into v_ode (DG0, quadrature space, ...)
-    def pde_to_ode(self) -> None:
-        local_project(self.v_pde, self.v_ode.function_space(), self.v_ode)
 
     @property
     def values(self):
@@ -122,7 +163,7 @@ class DolfinODESolver:
 
 
 @dataclass
-class DolfinMultiODESolver:
+class DolfinMultiODESolver(BaseDolfinODESolver):
     v_ode: dolfin.Function
     v_pde: dolfin.Function
     markers: dolfin.Function
@@ -162,6 +203,7 @@ class DolfinMultiODESolver:
                 states=self._values[marker],
                 parameters=self.parameters[marker],
             )
+        self._initialize_metadata()
 
     def _initialize_full_values(self):
         self._all_states_equal_size = (
@@ -185,14 +227,6 @@ class DolfinMultiODESolver:
         arr = self.v_ode.vector().get_local()
         for marker in self._marker_values:
             self._values[marker][self.v_index[marker], :] = arr[self._inds[marker]]
-
-    # ode_to_pde projects v_ode (DG0, quadrature space, ...) into v_pde (CG1)
-    def ode_to_pde(self) -> None:
-        local_project(self.v_ode, self.v_pde.function_space(), self.v_pde)
-
-    # pde_to_ode projects v_pde (CG1) into v_ode (DG0, quadrature space, ...)
-    def pde_to_ode(self) -> None:
-        local_project(self.v_pde, self.v_ode.function_space(), self.v_ode)
 
     def values(self, marker: int) -> npt.NDArray:
         return self._values[marker]

--- a/src/beat/odesolver.py
+++ b/src/beat/odesolver.py
@@ -62,7 +62,7 @@ class ODESystemSolver:
 class BaseDolfinODESolver(abc.ABC):
     v_ode: dolfin.Function
     v_pde: dolfin.Function
-    _metdata: dict[str, Any] | None = None
+    _metadata: dict[str, Any] | None = None
 
     def _initialize_metadata(self):
         if self.v_ode.ufl_element().family() == "Quadrature":

--- a/src/beat/utils.py
+++ b/src/beat/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing import Any
 import logging
 import dolfin
 import numpy.typing as npt
@@ -102,18 +104,36 @@ def expand_layer(
     return arr
 
 
-def local_project(v, V, u=None):
-    """Element-wise projection using LocalSolver"""
+def local_project(
+    v: dolfin.Function,
+    V: dolfin.FunctionSpace,
+    u: dolfin.Function | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dolfin.Function | None:
+    """Element-wise projection using LocalSolver
+
+    Parameters
+    ----------
+    v : dolfin.Function
+        Function to be projected
+    V : dolfin.FunctionSpace
+        Function space to project into
+    u : dolfin.Function | None, optional
+        Optional function to save the projected function, by default None
+
+    Returns
+    -------
+    dolfin.Function | None
+        The projected function
+    """
+
     dv = dolfin.TrialFunction(V)
     v_ = dolfin.TestFunction(V)
-    a_proj = ufl.inner(dv, v_) * ufl.dx
-    b_proj = ufl.inner(v, v_) * ufl.dx
+    a_proj = ufl.inner(dv, v_) * ufl.dx(metadata=metadata)
+    b_proj = ufl.inner(v, v_) * ufl.dx(metadata=metadata)
     solver = dolfin.LocalSolver(a_proj, b_proj)
     solver.factorize()
     if u is None:
         u = dolfin.Function(V)
-        solver.solve_local_rhs(u)
-        return u
-    else:
-        solver.solve_local_rhs(u)
-        return
+    solver.solve_local_rhs(u)
+    return u

--- a/tests/test_monodomain_solver.py
+++ b/tests/test_monodomain_solver.py
@@ -162,7 +162,7 @@ def test_monodomain_splitting_spatial_convergence(odespace):
     if degree > int(ode_degree):  # DG_0 (ODE) -> CG_1 (PDE)
         assert np.isclose(cvg_rate, int(ode_degree) + 1, rtol=0.1)
     else:
-        assert(np.isclose(cvg_rate, degree + 1, rtol=0.1))
+        assert np.isclose(cvg_rate, degree + 1, rtol=0.1)
 
 
 def test_monodomain_splitting_temporal_convergence():
@@ -222,7 +222,7 @@ def test_monodomain_splitting_temporal_convergence():
     rates = [np.log(e1 / e2) / np.log(2) for e1, e2 in zip(errors[:-1], errors[1:])]
     cvg_rate = sum(rates) / len(rates)
     # Forward Euler has error of order one in time
-    assert(np.isclose(cvg_rate, 1, rtol=0.01))
+    assert np.isclose(cvg_rate, 1, rtol=0.01)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adding tests for `CG_1`, `CG_2`, `DG_0`, `DG_1`, `Quadrature_2` and `Quadrature_4` and some small refactorings. For quadrature spaces we all need to pass the quadrature degree when performing integration. 

For some reason, `DG_0` fails for the spatial convergence tests, but this might be expected? Adding `xfail` (expected to fail) to that tests for now.

I am also wondering whether we can do the local project more efficiently. Since the projection is always between the same spaces, it should be possible to instantiate the local solver once and just update it during each call to `solve_local_rhs`, right?