### PR TITLE
Update method to compute expanded layers for BiV

### DIFF
--- a/demos/endocardial_stimulation.py
+++ b/demos/endocardial_stimulation.py
@@ -230,17 +230,15 @@ def main():
     markers = dolfin.Function(V)
     markers_path = datadir / "markers.xdmf"
     if not markers_path.is_file():
-        arr = beat.utils.expand_layer(
+        arr = beat.utils.expand_layer_biv(
             markers=markers,
             mfun=data.ffun,
-            endo_markers=[data.markers["ENDO_LV"][0], data.markers["ENDO_RV"][0]],
-            epi_markers=[data.markers["EPI"][0]],
-            endo_marker=1,
-            epi_marker=2,
+            endo_lv_marker=data.markers["ENDO_LV"][0],
+            endo_rv_marker=data.markers["ENDO_RV"][0],
+            epi_marker=data.markers["EPI"][0],
             endo_size=0.3,
             epi_size=0.3,
         )
-
         markers.vector().set_local(arr)
 
         with dolfin.XDMFFile(markers_path.as_posix()) as xdmf:

--- a/demos/endocardial_stimulation_odefile.py
+++ b/demos/endocardial_stimulation_odefile.py
@@ -228,13 +228,12 @@ def main():
     V = dolfin.FunctionSpace(data.mesh, "Lagrange", 1)
 
     markers = dolfin.Function(V)
-    arr = beat.utils.expand_layer(
+    arr = beat.utils.expand_layer_biv(
         markers=markers,
         mfun=data.ffun,
-        endo_markers=[data.markers["ENDO_LV"][0], data.markers["ENDO_RV"][0]],
-        epi_markers=[data.markers["EPI"][0]],
-        endo_marker=1,
-        epi_marker=2,
+        endo_lv_marker=data.markers["ENDO_LV"][0],
+        endo_rv_marker=data.markers["ENDO_RV"][0],
+        epi_marker=data.markers["EPI"][0],
         endo_size=0.3,
         epi_size=0.3,
     )

--- a/src/beat/utils.py
+++ b/src/beat/utils.py
@@ -40,8 +40,6 @@ def peval(f, *x):
 def expand_layer(
     markers: dolfin.Function,
     mfun: dolfin.MeshFunction,
-    endo_markers: list[int],
-    epi_markers: list[int],
     endo_marker: int,
     epi_marker: int,
     endo_size: float,
@@ -56,18 +54,10 @@ def expand_layer(
         Function where the markers are stored
     mfun : dolfin.MeshFunction
         Mesh function where the markers are stored
-    endo_markers: list[int]
-        List of markers for the endocardium. Should
-        be a subset of the markers in mfun
-    epimarkers: list[int]
-        List of markers for the epicardium. Should
-        be a subset of the markers in mfun
     endo_marker : int
-        Marker for the endocardium. Used to set the
-        marker on the array that is returned.
+        Marker for the endocardium.
     epi_marker : int
-        Marker for the epicardium. Used to set the
-        marker on the array that is returned.
+        Marker for the epicardium.
     endo_size : float
         Size of the endocardium
     epi_size : float
@@ -76,7 +66,9 @@ def expand_layer(
     Returns
     -------
     npt.NDArray
-        Array with the markers
+        Array with the markers with the value 1
+        on the endocardium, 2 on the epicardium
+        and 0 on the mid layer
     """
     # Find the rest of the laplace solutions
     V = markers.function_space()
@@ -107,28 +99,131 @@ def expand_layer(
     solver.set_from_options()
     sol_arrs = []
 
-    for endo in endo_markers:
-        for epi in epi_markers:
-            sol.vector()[:] = 0
+    sol.vector()[:] = 0
 
-            # Iterate over the three different cases
-            logger.info("Solving Laplace equation")
-            bcs = [
-                dolfin.DirichletBC(V, 0, mfun, endo, "topological"),
-                dolfin.DirichletBC(V, 1, mfun, epi, "topological"),
-            ]
-            A, b = dolfin.assemble_system(a, L, bcs)
+    # Iterate over the three different cases
+    logger.info("Solving Laplace equation")
+    bcs = [
+        dolfin.DirichletBC(V, 0, mfun, endo_marker, "topological"),
+        dolfin.DirichletBC(V, 1, mfun, epi_marker, "topological"),
+    ]
+    A, b = dolfin.assemble_system(a, L, bcs)
 
-            solver.set_operator(A)
-            solver.solve(sol.vector(), b)
+    solver.set_operator(A)
+    solver.solve(sol.vector(), b)
 
-            sol_arrs.append(sol.vector().get_local())
+    sol_arrs.append(sol.vector().get_local())
 
     # In BiV we have have one epi and two endo solutions
     # We take the minimum of the two endo solutions
     sol_arr = np.min(sol_arrs, axis=0)
-    arr[sol_arr < endo_size] = endo_marker
-    arr[sol_arr > 1 - epi_size] = epi_marker
+    arr[sol_arr < endo_size] = 1
+    arr[sol_arr > 1 - epi_size] = 2
+    return arr
+
+
+def expand_layer_biv(
+    markers: dolfin.Function,
+    mfun: dolfin.MeshFunction,
+    endo_lv_marker: int,
+    endo_rv_marker: int,
+    epi_marker: int,
+    endo_size: float,
+    epi_size: float,
+) -> npt.NDArray:
+    """Expand the endo and epi markers to the rest of the mesh
+    with a given size. Used for BiV geometries.
+
+    Parameters
+    ----------
+    markers : dolfin.Function
+        Function where the markers are stored
+    mfun : dolfin.MeshFunction
+        Mesh function where the markers are stored
+    endo_lv_marker : int
+        Marker for the LV endocardium.
+    endo_lv_marker : int
+        Marker for the RV endocardium.
+    epi_marker : int
+        Marker for the epicardium.
+    endo_size : float
+        Size of the endocardium
+    epi_size : float
+        Size of the epicardium
+
+    Returns
+    -------
+    npt.NDArray
+        Array with the markers with the value 1
+        on the endocardium, 2 on the epicardium
+        and 0 on the mid layer
+    """
+    # Find the rest of the laplace solutions
+    V = markers.function_space()
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    arr = markers.vector().get_local().copy()
+    sol = dolfin.Function(V)
+
+    a = ufl.dot(ufl.grad(u), ufl.grad(v)) * ufl.dx
+    L = v * dolfin.Constant(0) * ufl.dx
+
+    solver = dolfin.PETScKrylovSolver()
+    dolfin.PETScOptions.set("ksp_type", "cg")
+    dolfin.PETScOptions.set("ksp_norm_type", "unpreconditioned")
+    dolfin.PETScOptions.set("ksp_atol", 1e-15)
+    dolfin.PETScOptions.set("ksp_rtol", 1e-10)
+    dolfin.PETScOptions.set("ksp_max_it", 10_000)
+    dolfin.PETScOptions.set("ksp_error_if_not_converged", False)
+    # if ksp_monitor:
+    #     dolfin.PETScOptions.set("ksp_monitor")
+    # if ksp_view:
+    #     dolfin.PETScOptions.set("ksp_view")
+    dolfin.PETScOptions.set("pc_type", "hypre")
+    dolfin.PETScOptions.set("pc_hypre_type", "boomeramg")
+    # if pc_view:
+    #     dolfin.PETScOptions.set("pc_view")
+    solver.set_from_options()
+    sol_arrs = []
+
+    mfun_original = mfun.array().copy()
+
+    # Solve LV - RV + EPI
+    sol.vector()[:] = 0
+    # Iterate over the three different cases
+    logger.info("Solving Laplace equation for LV - RV + EPI")
+    mfun.array()[mfun_original == endo_rv_marker] = epi_marker
+    bcs = [
+        dolfin.DirichletBC(V, 0, mfun, endo_lv_marker, "topological"),
+        dolfin.DirichletBC(V, 1, mfun, epi_marker, "topological"),
+    ]
+    A, b = dolfin.assemble_system(a, L, bcs)
+
+    solver.set_operator(A)
+    solver.solve(sol.vector(), b)
+    sol_arrs.append(sol.vector().get_local())
+
+    # Solve RV - LV + EPI
+    sol.vector()[:] = 0
+    # Iterate over the three different cases
+    logger.info("Solving Laplace equation for RV - LV + EPI")
+    mfun.array()[:] = mfun_original
+    mfun.array()[mfun_original == endo_lv_marker] = epi_marker
+    bcs = [
+        dolfin.DirichletBC(V, 0, mfun, endo_rv_marker, "topological"),
+        dolfin.DirichletBC(V, 1, mfun, epi_marker, "topological"),
+    ]
+    A, b = dolfin.assemble_system(a, L, bcs)
+
+    solver.set_operator(A)
+    solver.solve(sol.vector(), b)
+    sol_arrs.append(sol.vector().get_local())
+
+    # In BiV we have have one epi and two endo solutions
+    # We take the minimum of the two endo solutions
+    sol_arr = np.min(sol_arrs, axis=0)
+    arr[sol_arr < endo_size] = 1
+    arr[sol_arr > 1 - epi_size] = 2
     return arr
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,18 +39,14 @@ def test_expand_layer_single():
 
     V = dolfin.FunctionSpace(mesh, "Lagrange", 1)
     markers = dolfin.Function(V)
-    arr = beat.utils.expand_layer(
-        markers=markers,
+    markers = beat.utils.expand_layer(
+        V=V,
         mfun=mfun,
-        endo_markers=[endo_marker],
-        epi_markers=[epi_marker],
         endo_marker=endo_marker,
         epi_marker=epi_marker,
         endo_size=0.3,
         epi_size=0.3,
     )
-
-    markers.vector().set_local(arr)
 
     # Just check a few values
     for x in [0.0, 0.1, 0.2]:
@@ -61,36 +57,44 @@ def test_expand_layer_single():
 
 
 def test_expand_layer_double():
-    mesh = dolfin.UnitSquareMesh(10, 10)
+    mesh = dolfin.UnitSquareMesh(40, 40)
 
     mfun = dolfin.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
     mfun.set_all(0)
-    mid_marker = 0
-    endo_marker = 1
-    endo_marker2 = 2
+    endo_lv_marker = 1
+    endo_rv_marker = 2
     epi_marker = 3
-    dolfin.CompiledSubDomain("near(x[0], 0) && x[1] <= 0.5").mark(mfun, endo_marker)
-    dolfin.CompiledSubDomain("near(x[0], 0) && x[1] >= 0.5").mark(mfun, endo_marker2)
+    dolfin.CompiledSubDomain("near(x[1], 0) && x[0] <= 0.5").mark(mfun, endo_lv_marker)
+    dolfin.CompiledSubDomain("near(x[1], 1) && x[0] <= 0.5").mark(mfun, endo_rv_marker)
     dolfin.CompiledSubDomain("near(x[0], 1)").mark(mfun, epi_marker)
 
     V = dolfin.FunctionSpace(mesh, "Lagrange", 1)
-    markers = dolfin.Function(V)
-    arr = beat.utils.expand_layer(
-        markers=markers,
+    markers = beat.utils.expand_layer_biv(
+        V=V,
         mfun=mfun,
-        endo_markers=[endo_marker, endo_marker2],
-        epi_markers=[epi_marker],
-        endo_marker=1,
+        endo_lv_marker=endo_lv_marker,
+        endo_rv_marker=endo_rv_marker,
         epi_marker=epi_marker,
         endo_size=0.3,
         epi_size=0.3,
     )
 
-    markers.vector().set_local(arr)
+    # Endo in the upp left and lower left coners
+    for y_value in [0.0, 1.0, 0.2, 0.8]:
+        for x_value in [0.0, 0.1]:
+            assert np.isclose(peval(markers, (x_value, y_value)), 1.0)
 
-    # Just check a few values
-    for x in [0.0, 0.1, 0.2]:
-        for y in [0.0, 0.5, 1.0]:
-            assert np.isclose(peval(markers, (x, y)), endo_marker)
-            assert np.isclose(peval(markers, (x + 0.4, y)), mid_marker)
-            assert np.isclose(peval(markers, (1 - x, y)), epi_marker)
+    # Mid should be beween the two endo
+    for y_value in [0.4, 0.6]:
+        for x_value in [0.0, 0.1]:
+            assert np.isclose(peval(markers, (x_value, y_value)), 0.0)
+
+    # and between endo and epi
+    for y_value in [0.0, 1.0]:
+        for x_value in [0.6, 0.7]:
+            assert np.isclose(peval(markers, (x_value, y_value)), 0.0)
+
+    # Epi should be to the right
+    for y_value in [0.0, 0.5, 1.0]:
+        for x_value in [0.9, 1.0]:
+            assert np.isclose(peval(markers, (x_value, y_value)), 2.0)


### PR DESCRIPTION
Fix expand layer for BiV geometries. Old markers looks like 
<img width="238" alt="image" src="https://github.com/finsberg/fenics-beat/assets/2010323/f0f9b805-b67a-4c91-8b96-e1473ff2c5a5">
New markers look like
<img width="484" alt="image" src="https://github.com/finsberg/fenics-beat/assets/2010323/123a51e0-0bcb-435a-b3f6-8718c4acfd81">
